### PR TITLE
Feature: Initial implementation of ulrack/search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.0.0 - 2019-03-04
+### Added
+- Initial implementation of ulrack/search
+- `Ulrack\Search\Common\FilterGroupInterface`
+- `Ulrack\Search\Common\FilterInterface`
+- `Ulrack\Search\Common\LimiterInterface`
+- `Ulrack\Search\Common\PagerInterface`
+- `Ulrack\Search\Common\SearchCriteriaCompilerInterface`
+- `Ulrack\Search\Common\SearchCriteriaInterface`
+- `Ulrack\Search\Common\SorterInterface`
+- `Ulrack\Search\Criteria\FilterGroup`
+- `Ulrack\Search\Criteria\Filter`
+- `Ulrack\Search\Criteria\Limiter`
+- `Ulrack\Search\Criteria\Pager`
+- `Ulrack\Search\Criteria\SearchCriteria`
+- `Ulrack\Search\Criteria\Sorter`
+- Unit Tests
+
+### Changed
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Removed
+- Nothing
+
+### Fixed
+- Nothing
+
+### Security
+- Nothing
+
+[Unreleased]: https://github.com/ulrack/search/compare/1.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -1,0 +1,174 @@
+[![Build Status](https://travis-ci.com/ulrack/search.svg?branch=master)](https://travis-ci.com/ulrack/search)
+
+# Ulrack Search
+
+Ulrack Search is an implementation of search criteria for applications.
+It tries to talk to data in application through a common interface.
+
+## Installation
+
+To install the package run the following command:
+
+```
+composer require ulrack/search
+```
+
+## Usage
+
+### Search Criteria Compilers
+
+Search criteria compilers are used to compile a filled search criteria object.
+The output can be used by a package apply the search criteria to the data query.
+
+There is no implementation provided in this package for a compiler.
+This is because it is application specific.
+
+A search criteria compiler can be created by extending the `\Ulrack\Search\Common\SearchCriteriaCompilerInterface`.
+The implementation expects one function `compile`.
+The function accepts a `\Ulrack\Search\Common\SearchCriteriaInterface` object as an argument.
+This object should then be compiled to whatever the application expects.
+
+### Search Criteria
+
+Search criteria objects are build on the `\Ulrack\Search\Common\SearchCriteriaInterface`.
+These objects group all underlying search related objects by getting these injected.
+
+The implementation is provided in the class `\Ulrack\Search\Criteria\SearchCriteria`.
+
+The `SearchCriteria` object can receive and retrieve the following objects:
+- `\Ulrack\Search\Common\FilterGroupInterface`
+Can be added by calling: `addFilterGroup` with the `FilterGroup` as an argument.
+Can be retrieved by calling: `getFilterGroups` and will return an array of `FilterGroups`.
+
+- `\Ulrack\Search\Common\LimiterInterface`
+Can be added by calling: `addLimiter` with the `Limiter` as an argument.
+Can be retrieved by calling: `getLimiters` and will return an array of `Limiters`.
+
+- `\Ulrack\Search\Common\PagerInterface`
+Can be added by calling: `addPager` with the `Pager` as an argument.
+Can be retrieved by calling: `getPagers` and will return an array of `Pagers`.
+
+- `\Ulrack\Search\Common\SorterInterface`
+Can be added by calling: `addSorter` with the `Sorter` as an argument.
+Can be retrieved by calling: `getSorters` and will return an array of `Sorters`.
+
+### Filter Groups
+
+Filter groups are used to combine filters into one (in the case of SQL `AND` separated) group of filters.
+Multiple `FilterGroups` on a `SearchCriteria` would result in (in the case of SQL) `OR` separated filters.
+
+A `Filter` can be added to the filter group by calling: `addFilter`.
+It accepts an instance of `\Ulrack\Search\Common\FilterInterface` as its argument.
+To retrieve the added `Filters` in an array, the function `getFilters` can be called.
+
+### Filters
+
+Filters are used to narrow down the results of a request by matching values to a field with a comparator.
+
+Filters expect their arguments in the constructor.
+The first argument expects a field for the filter.
+The second argument expects a comparator,
+which should be one of of the following out of the `\Ulrack\Search\Common\FilterInterface`:
+- `FilterInterface::COMPARATOR_EQ`
+Equals comparator "=". Checks if the field equals the value.
+
+- `FilterInterface::COMPARATOR_NEQ`
+Not equals comparator "!=". Checks if the field does not equal the value.
+
+- `FilterInterface::COMPARATOR_GT`
+Greater than comparator ">". Check if the field is greater than the value.
+
+- `FilterInterface::COMPARATOR_GTEQ`
+Greater than or equals comparator ">=".
+Checks if the field is greater than or equals the value.
+
+- `FilterInterface::COMPARATOR_LT`
+Less than comparator "<". Check if the field is less than the value.
+
+- `FilterInterface::COMPARATOR_LTEQ`
+Less than or equals comparator "<=".
+Checks if the field is less than or equals the value.
+
+- `FilterInterface::COMPARATOR_IN`
+In comparator. Checks if the field occurs in the value.
+
+- `FilterInterface::COMPARATOR_NIN`
+Not in comparator. Checks if the field does not occur in the value.
+
+- `FilterInterface::COMPARATOR_LIKE`
+Like comparator. Checks if the field looks like the value.
+
+- `FilterInterface::COMPARATOR_NOT`
+Not comparator. Checks if the field is not like the value.
+Can be used for example in a query for a NOT NULL statement.
+
+The third argument expects the value which should be compared.
+
+The field can be retrieved with the `getField` function.
+The comparator can be retrieved with the `getComparator` function.
+The value can be retrieved with the `getValue` function.
+
+### Limiters
+
+Limiters are used to reduce the size of the result.
+
+Limiters expect their arguments in the constructor.
+One variadic argument can be supplied which consists of the fields.
+
+The fields can be retrieved with the `getFields` function.
+
+### Pagers
+
+Pagers are used to retrieve a section of the results.
+
+Pagers expect their arguments in the constructor.
+The first argument of a `Pager` expects an integer which indicates the page.
+The second argument of a `Pager` expects an integer which determines the page size.
+
+The page can be retrieved with the function `getPage`.
+The size can be retrieved with the function `getSize`.
+
+### Sorters
+
+Sorters are used to sort the results of a data request.
+
+Sorters expect their arguments in the constructor.
+The first argument of a `Sorter` expects a string which indicates the field.
+The second argument of a `Sorter` expects a string which indicates the direction.
+
+The direction can be one of the following from the `\Ulrack\Search\Common\SorterInterface`:
+- `SorterInterface::DIRECTION_ASC`
+This sets the sorting pattern to ascending.
+
+- `SorterInterface::DIRECTION_DESC`
+This sets the sorting pattern to descending.
+
+## Change log
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) for details.
+
+## MIT License
+
+Copyright (c) 2019 Jyxon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,48 @@
+{
+  "name": "ulrack/search",
+  "description": "Search objects for Ulrack.",
+  "keywords": ["search"],
+  "type": "library",
+  "license": "MIT",
+  "prefer-stable": true,
+  "minimum-stability": "stable",
+  "require": {
+    "php": "^7.2"
+  },
+  "authors": [
+    {
+      "name": "Ulrack",
+      "homepage": "https://www.ulrack.com/",
+      "role": "Developer"
+    }
+  ],
+  "config": {
+    "sort-packages": true
+  },
+  "autoload": {
+    "psr-4": {
+      "Ulrack\\Search\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Ulrack\\Search\\Tests\\": "tests/"
+    }
+  },
+  "archive": {
+    "exclude": [
+      "/tests",
+      "/.gitignore",
+      "/.travis.yml",
+      "/phpunit.xml",
+      "/phpcs.xml",
+      "/PULL_REQUEST_TEMPLATE.md",
+      "/CODE_OF_CONDUCT.md",
+      "/CONTRIBUTING.md"
+    ]
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^8.0",
+    "squizlabs/php_codesniffer": "^3.4"
+  }
+}

--- a/src/Common/FilterGroupInterface.php
+++ b/src/Common/FilterGroupInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface FilterGroupInterface
+{
+    /**
+     * Retrieves filters from the FilterGroupInterface.
+     *
+     * @return FilterInterface[]
+     */
+    public function getFilters(): array;
+
+    /**
+     * Add filter to the FilterGroupInterface
+     *
+     * @param FilterInterface $filter
+     *
+     * @return void
+     */
+    public function addFilter(FilterInterface $filter): void;
+}

--- a/src/Common/FilterInterface.php
+++ b/src/Common/FilterInterface.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface FilterInterface
+{
+    /**
+     * Equals comparator "=".
+     * Checks if the field equals the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_EQ = 'eq';
+
+    /**
+     * Not equals comparator "!=".
+     * Checks if the field does not equal the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_NEQ = 'neq';
+
+    /**
+     * Greater than comparator ">".
+     * Checks if the field is greater than the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_GT = 'gt';
+
+    /**
+     * Greater than or equals comparator ">=".
+     * Checks if the field is greater than or equals the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_GTEQ = 'gteq';
+
+    /**
+     * Less than comparator "<".
+     * Checks if the field is less than the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_LT = 'lt';
+
+    /**
+     * Less than or equals comparator "<=".
+     * Checks if the field is less than or equals the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_LTEQ = 'lteq';
+
+    /**
+     * In comparator.
+     * Checks if the field occurs in the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_IN = 'in';
+
+    /**
+     * Not in comparator.
+     * Checks if the field does not occur in the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_NIN = 'nin';
+
+    /**
+     * Like comparator.
+     * Checks if the field looks like the value.
+     *
+     * @var string
+     */
+    const COMPARATOR_LIKE = 'like';
+
+    /**
+     * Not comparator.
+     * Checks if the field is not like the value.
+     * Can be used for example in a query for a NOT NULL statement.
+     *
+     * @var string
+     */
+    const COMPARATOR_NOT = 'not';
+
+    /**
+     * Retrieves the field which should be compared.
+     *
+     * @return string
+     */
+    public function getField(): string;
+
+    /**
+     * Retrieves the comparator used in the comparison of field and value.
+     *
+     * @return string
+     */
+    public function getComparator(): string;
+
+    /**
+     * Retrieves the value which should be compared against.
+     *
+     * @return mixed
+     */
+    public function getValue();
+}

--- a/src/Common/LimiterInterface.php
+++ b/src/Common/LimiterInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface LimiterInterface
+{
+    /**
+     * Retrieves the fields which should be fetched by the SearchCriteriaInterface.
+     *
+     * @return string[]
+     */
+    public function getFields(): array;
+}

--- a/src/Common/PagerInterface.php
+++ b/src/Common/PagerInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface PagerInterface
+{
+    /**
+     * Retrieves the currently requested page for the SearchCriteriaInterface.
+     *
+     * @return int
+     */
+    public function getPage(): int;
+
+    /**
+     * Retrieves the amount of items on the page.
+     *
+     * @return int
+     */
+    public function getAmount(): int;
+}

--- a/src/Common/SearchCriteriaCompilerInterface.php
+++ b/src/Common/SearchCriteriaCompilerInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface SearchCriteriaCompilerInterface
+{
+    /**
+     * Compiles the SearchCriteriaInterface to a purposeful export.
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     *
+     * @return mixed
+     */
+    public function compile(SearchCriteriaInterface $searchCriteria);
+}

--- a/src/Common/SearchCriteriaInterface.php
+++ b/src/Common/SearchCriteriaInterface.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface SearchCriteriaInterface
+{
+    /**
+     * Adds a filter group to the SearchCriteriaInterface.
+     *
+     * @param FilterGroupInterface $filter
+     *
+     * @return void
+     */
+    public function addFilterGroup(FilterGroupInterface $filterGroup): void;
+
+    /**
+     * Retrieves the filter groups from the SearchCriteriaInterface.
+     *
+     * @return FilterGroupInterface[]
+     */
+    public function getFilterGroups(): array;
+
+    /**
+     * Adds a sorter to the SearchCriteriaInterface.
+     *
+     * @param SorterInterface $sorter
+     *
+     * @return void
+     */
+    public function addSorter(SorterInterface $sorter): void;
+
+    /**
+     * Retrieves the sorters from the SearchCriteriaInterface.
+     *
+     * @return SorterInterface[]
+     */
+    public function getSorters(): array;
+
+    /**
+     * Adds a pager to the SearchCriteriaInterface.
+     *
+     * @param PagerInterface $pager
+     *
+     * @return void
+     */
+    public function addPager(PagerInterface $pager): void;
+
+    /**
+     * Retrieves the pagers from the SearchCriteriaInterface.
+     *
+     * @return PagerInterface[]
+     */
+    public function getPagers(): array;
+
+    /**
+     * Adds a limiter to the SearchCriteriaInterface.
+     *
+     * @param LimiterInterface $limiter
+     *
+     * @return void
+     */
+    public function addLimiter(LimiterInterface $limiter): void;
+
+    /**
+     * Retrieves the limiters from the SearchCriteriaInterface.
+     *
+     * @return LimiterInterface[]
+     */
+    public function getLimiters(): array;
+}

--- a/src/Common/SorterInterface.php
+++ b/src/Common/SorterInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Common;
+
+interface SorterInterface
+{
+    /**
+     * Directs the sorting in ascending order.
+     *
+     * @var string
+     */
+    const DIRECTION_ASC = 'asc';
+
+    /**
+     * Directs the sorting in descending order.
+     *
+     * @var string
+     */
+    const DIRECTION_DESC = 'desc';
+
+    /**
+     * Retrieves the direction of the sorting.
+     *
+     * @return string
+     */
+    public function getDirection(): string;
+
+    /**
+     * Retrieves the field on which should be sorted.
+     *
+     * @return string
+     */
+    public function getField(): string;
+}

--- a/src/Criteria/Filter.php
+++ b/src/Criteria/Filter.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\FilterInterface;
+
+class Filter implements FilterInterface
+{
+    /** @var string */
+    private $field;
+
+    /** @var string */
+    private $comparator;
+
+    /** @var mixed */
+    private $value;
+
+    /**
+     * Constructor
+     *
+     * @param string $field
+     * @param string $comparator
+     * @param mixed  $value
+     */
+    public function __construct(string $field, string $comparator, $value)
+    {
+        $this->field = $field;
+        $this->comparator = $comparator;
+        $this->value = $value;
+    }
+
+    /**
+     * Retrieves the field which should be compared.
+     *
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * Retrieves the comparator used in the comparison of field and value.
+     *
+     * @return string
+     */
+    public function getComparator(): string
+    {
+        return $this->comparator;
+    }
+
+    /**
+     * Retrieves the value which should be compared against.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Criteria/FilterGroup.php
+++ b/src/Criteria/FilterGroup.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\FilterInterface;
+
+class FilterGroup
+{
+    /** @var FilterInterface[] */
+    private $filters;
+
+    /**
+     * Retrieves filters from the FilterGroupInterface.
+     *
+     * @return FilterInterface[]
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+
+    /**
+     * Add filter to the FilterGroupInterface
+     *
+     * @param FilterInterface $filter
+     *
+     * @return void
+     */
+    public function addFilter(FilterInterface $filter): void
+    {
+        $this->filters[] = $filter;
+    }
+}

--- a/src/Criteria/Limiter.php
+++ b/src/Criteria/Limiter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\LimiterInterface;
+
+class Limiter implements LimiterInterface
+{
+    /** @var array */
+    private $fields;
+
+    /**
+     * Constructor
+     *
+     * @param string ...$fields
+     */
+    public function __construct(string ...$fields)
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * Retrieves the fields which should be fetched by the SearchCriteriaInterface.
+     *
+     * @return string[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+}

--- a/src/Criteria/Pager.php
+++ b/src/Criteria/Pager.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\PagerInterface;
+
+class Pager implements PagerInterface
+{
+    /** @var int */
+    private $page;
+
+    /** @var int */
+    private $amount;
+
+    /**
+     * Constructor
+     *
+     * @param int $page
+     * @param int $amount
+     */
+    public function __construct(int $page, int $amount)
+    {
+        $this->page = $page;
+        $this->amount = $amount;
+    }
+
+    /**
+     * Retrieves the currently requested page for the SearchCriteriaInterface.
+     *
+     * @return int
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    /**
+     * Retrieves the amount of items on the page.
+     *
+     * @return int
+     */
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+}

--- a/src/Criteria/SearchCriteria.php
+++ b/src/Criteria/SearchCriteria.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\FilterGroupInterface;
+use Ulrack\Search\Common\LimiterInterface;
+use Ulrack\Search\Common\PagerInterface;
+use Ulrack\Search\Common\SearchCriteriaInterface;
+use Ulrack\Search\Common\SorterInterface;
+
+class SearchCriteria implements SearchCriteriaInterface
+{
+    /** @var FilterGroupInterface[] */
+    private $filterGroups;
+
+    /** @var LimiterInterface[] */
+    private $limiters;
+
+    /** @var PagerInterface[] */
+    private $pagers;
+
+    /** @var SorterInterface[] */
+    private $sorters;
+
+    /**
+     * Adds a filter group to the SearchCriteriaInterface.
+     *
+     * @param FilterGroupInterface $filter
+     *
+     * @return void
+     */
+    public function addFilterGroup(FilterGroupInterface $filterGroup): void
+    {
+        $this->filterGroups[] = $filterGroup;
+    }
+
+    /**
+     * Retrieves the filter groups from the SearchCriteriaInterface.
+     *
+     * @return FilterGroupInterface[]
+     */
+    public function getFilterGroups(): array
+    {
+        return $this->filterGroups;
+    }
+
+    /**
+     * Adds a sorter to the SearchCriteriaInterface.
+     *
+     * @param SorterInterface $sorter
+     *
+     * @return void
+     */
+    public function addSorter(SorterInterface $sorter): void
+    {
+        $this->sorters[] = $sorter;
+    }
+
+    /**
+     * Retrieves the sorters from the SearchCriteriaInterface.
+     *
+     * @return SorterInterface[]
+     */
+    public function getSorters(): array
+    {
+        return $this->sorters;
+    }
+
+    /**
+     * Adds a pager to the SearchCriteriaInterface.
+     *
+     * @param PagerInterface $pager
+     *
+     * @return void
+     */
+    public function addPager(PagerInterface $pager): void
+    {
+        $this->pagers[] = $pager;
+    }
+
+    /**
+     * Retrieves the pagers from the SearchCriteriaInterface.
+     *
+     * @return PagerInterface[]
+     */
+    public function getPagers(): array
+    {
+        return $this->pagers;
+    }
+
+    /**
+     * Adds a limiter to the SearchCriteriaInterface.
+     *
+     * @param LimiterInterface $limiter
+     *
+     * @return void
+     */
+    public function addLimiter(LimiterInterface $limiter): void
+    {
+        $this->limiters[] = $limiter;
+    }
+
+    /**
+     * Retrieves the limiters from the SearchCriteriaInterface.
+     *
+     * @return LimiterInterface[]
+     */
+    public function getLimiters(): array
+    {
+        return $this->limiters;
+    }
+}

--- a/src/Criteria/Sorter.php
+++ b/src/Criteria/Sorter.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Criteria;
+
+use Ulrack\Search\Common\SorterInterface;
+
+class Sorter implements SorterInterface
+{
+    /** @var string */
+    private $direction;
+
+    /** @var string */
+    private $field;
+
+    /**
+     * Constructor
+     *
+     * @param string $field
+     * @param string $direction
+     */
+    public function __construct(string $field, string $direction)
+    {
+        $this->field = $field;
+        $this->direction = $direction;
+    }
+
+    /**
+     * Retrieves the direction of the sorting.
+     *
+     * @return string
+     */
+    public function getDirection(): string
+    {
+        return $this->direction;
+    }
+
+    /**
+     * Retrieves the field on which should be sorted.
+     *
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+}

--- a/tests/Criteria/FilterGroupTest.php
+++ b/tests/Criteria/FilterGroupTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\FilterGroup;
+use Ulrack\Search\Common\FilterInterface;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\FilterGroup
+ */
+class FilterGroupTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::getFilters
+     * @covers ::addFilter
+     */
+    public function testFilter(): void
+    {
+        $subject = new FilterGroup();
+
+        $filterMock = $this->createMock(FilterInterface::class);
+        $subject->addFilter($filterMock);
+        $this->assertEquals([$filterMock], $subject->getFilters());
+    }
+}

--- a/tests/Criteria/FilterTest.php
+++ b/tests/Criteria/FilterTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\Filter;
+use Ulrack\Search\Common\FilterInterface;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\Filter
+ */
+class FilterTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::getField
+     * @covers ::getValue
+     * @covers ::getComparator
+     */
+    public function testFilter(): void
+    {
+        $subject = new Filter('foo', FilterInterface::COMPARATOR_EQ, 'bar');
+        $this->assertInstanceOf(Filter::class, $subject);
+        $this->assertEquals('foo', $subject->getField());
+        $this->assertEquals(FilterInterface::COMPARATOR_EQ, $subject->getComparator());
+        $this->assertEquals('bar', $subject->getValue());
+    }
+}

--- a/tests/Criteria/LimiterTest.php
+++ b/tests/Criteria/LimiterTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\Limiter;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\Limiter
+ */
+class LimiterTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::getFields
+     */
+    public function testLimiter(): void
+    {
+        $subject = new Limiter('foo', 'bar');
+        $this->assertInstanceOf(Limiter::class, $subject);
+        $this->assertEquals(['foo', 'bar'], $subject->getFields());
+    }
+}

--- a/tests/Criteria/PagerTest.php
+++ b/tests/Criteria/PagerTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\Pager;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\Pager
+ */
+class PagerTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::getPage
+     * @covers ::getAmount
+     */
+    public function testPager(): void
+    {
+        $subject = new Pager(1, 50);
+        $this->assertInstanceOf(Pager::class, $subject);
+        $this->assertEquals(1, $subject->getPage());
+        $this->assertEquals(50, $subject->getAmount());
+    }
+}

--- a/tests/Criteria/SearchCriteriaTest.php
+++ b/tests/Criteria/SearchCriteriaTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\SearchCriteria;
+use Ulrack\Search\Common\SearchCriteriaInterface;
+use Ulrack\Search\Common\FilterGroupInterface;
+use Ulrack\Search\Common\SorterInterface;
+use Ulrack\Search\Common\PagerInterface;
+use Ulrack\Search\Common\LimiterInterface;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\SearchCriteria
+ */
+class SearchCriteriaTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::addFilterGroup
+     * @covers ::getFilterGroups
+     * @covers ::addSorter
+     * @covers ::getSorters
+     * @covers ::addPager
+     * @covers ::getPagers
+     * @covers ::addLimiter
+     * @covers ::getLimiters
+     */
+    public function testSearchCriteria(): void
+    {
+        $subject = new SearchCriteria();
+
+        $filterGroupMock = $this->createMock(FilterGroupInterface::class);
+        $subject->addFilterGroup($filterGroupMock);
+        $this->assertEquals([$filterGroupMock], $subject->getFilterGroups());
+
+        $sorterMock = $this->createMock(SorterInterface::class);
+        $subject->addSorter($sorterMock);
+        $this->assertEquals([$sorterMock], $subject->getSorters());
+
+        $pagerMock = $this->createMock(PagerInterface::class);
+        $subject->addPager($pagerMock);
+        $this->assertEquals([$pagerMock], $subject->getPagers());
+
+        $limiterMock = $this->createMock(LimiterInterface::class);
+        $subject->addLimiter($limiterMock);
+        $this->assertEquals([$limiterMock], $subject->getLimiters());
+    }
+}

--- a/tests/Criteria/SorterTest.php
+++ b/tests/Criteria/SorterTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (C) Jyxon, Inc. All rights reserved.
+ * See LICENSE for license details.
+ */
+
+namespace Ulrack\Search\Tests\Criteria;
+
+use PHPUnit\Framework\TestCase;
+use Ulrack\Search\Criteria\Sorter;
+use Ulrack\Search\Common\SorterInterface;
+
+/**
+ * @coversDefaultClass \Ulrack\Search\Criteria\Sorter
+ */
+class SorterTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::__construct
+     * @covers ::getDirection
+     * @covers ::getField
+     */
+    public function testSorter(): void
+    {
+        $subject = new Sorter('foo', SorterInterface::DIRECTION_ASC);
+        $this->assertInstanceOf(Sorter::class, $subject);
+        $this->assertEquals('foo', $subject->getField());
+        $this->assertEquals(
+            SorterInterface::DIRECTION_ASC,
+            $subject->getDirection()
+        );
+    }
+}


### PR DESCRIPTION
## 1.0.0 - 2019-03-04
### Added
- Initial implementation of ulrack/search
- `Ulrack\Search\Common\FilterGroupInterface`
- `Ulrack\Search\Common\FilterInterface`
- `Ulrack\Search\Common\LimiterInterface`
- `Ulrack\Search\Common\PagerInterface`
- `Ulrack\Search\Common\SearchCriteriaCompilerInterface`
- `Ulrack\Search\Common\SearchCriteriaInterface`
- `Ulrack\Search\Common\SorterInterface`
- `Ulrack\Search\Criteria\FilterGroup`
- `Ulrack\Search\Criteria\Filter`
- `Ulrack\Search\Criteria\Limiter`
- `Ulrack\Search\Criteria\Pager`
- `Ulrack\Search\Criteria\SearchCriteria`
- `Ulrack\Search\Criteria\Sorter`
- Unit Tests